### PR TITLE
push: fix script failure with undefined LIFETIME

### DIFF
--- a/push-to-neofs.py
+++ b/push-to-neofs.py
@@ -242,6 +242,7 @@ def push_files_to_neofs(
     if not os.listdir(directory):
         raise Exception(f"Directory '{directory}' is empty.")
 
+    expiration_epoch = None
     if lifetime is not None and lifetime > 0:
         current_epoch = get_current_epoch(endpoint)
         expiration_epoch = current_epoch + lifetime


### PR DESCRIPTION
  File "/home/runner/work/_actions/nspcc-dev/gh-push-to-neofs/master/push-to-neofs.py", line 287, in <module>
    push_files_to_neofs(
  File "/home/runner/work/_actions/nspcc-dev/gh-push-to-neofs/master/push-to-neofs.py", line 275, in push_files_to_neofs
    expiration_epoch,
    ^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'expiration_epoch' where it is not associated with a value